### PR TITLE
Switch to Aptible Ubuntu base image and use apt-install (to incorporate apt-get update)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:14.04
+FROM quay.io/aptible/ubuntu:14.04
 
-RUN sudo apt-get install -y curl
+RUN apt-install curl
 RUN curl https://s3-us-west-2.amazonaws.com/mode-distribution/public/release/mode-bridge/linux-container/latest.tgz | tar -zxvf -
 
 WORKDIR mode


### PR DESCRIPTION
This issue is intended to fix this bug when building the current Dockerfile:

```
E: Unable to locate package curl
 The command [/bin/sh -c sudo apt-get install -y curl] returned a non-zero code: 100
```

This error happens when the APT cache becomes stale, and it's necessary to run `apt-get update` before `apt-get install [...]` in order to avoid this.

I've switched to our `quay.io/aptible/ubuntu:14.04` image out of habit, but an alternative approach would simply be to add:

```
RUN sudo apt-get update
```

before

```
RUN sudo apt-get install -y curl
```
