### PR TITLE
update apt-get to prevent 'curl not found' error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-RUN sudo apt-get install -y curl
+RUN sudo apt-get update && sudo apt-get install -y curl
 RUN curl https://s3-us-west-2.amazonaws.com/mode-distribution/public/release/mode-bridge/linux-container/latest.tgz | tar -zxvf -
 
 WORKDIR mode


### PR DESCRIPTION
This PR solves the same issue as #1 except we do not update the ubuntu version from quay/Aptible. Though Ubuntu 14.04 is slightly dated, it is stable, and we assume the `mode-bridge` was intended to run on this version.

![screen shot 2017-06-07 at 12 43 05 pm](https://user-images.githubusercontent.com/1189356/26897901-f5b65366-4b7e-11e7-9b07-b5c04d2eecb1.png)

